### PR TITLE
Added convertToAbsolute option to accommodate css relocation without image relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ production. I want this final file for the css above:
 
 ## Using the 'convertToAbsolute' option
 
-This option will prefix the rebased relative URL with a forward slash to convert it into an absolute path. This is to accomodate situations where the CSS files are being transferred into another directory (such as a temp directory for generated files) but the images aren't being relocated.
+This option will prefix the rebased relative URL with a forward slash to convert it into an absolute path. This is to accommodate situations where the CSS files are being transferred into another directory (such as a temp directory for generated files) but the images aren't being relocated.
 
 By default the option is turned off.
 

--- a/README.md
+++ b/README.md
@@ -74,4 +74,28 @@ production. I want this final file for the css above:
 }
 ```
 
+## Using the 'convertToAbsolute' option
+
+This option will prefix the rebased relative URL with a forward slash to convert it into an absolute path. This is to accomodate situations where the CSS files are being transferred into another directory (such as a temp directory for generated files) but the images aren't being relocated.
+
+By default the option is turned off.
+
+### Example
+
+```javascript
+var gulp = require('gulp');
+var rebaseUrls = require('gulp-css-rebase-urls');
+
+gulp.task('default', function () {
+    gulp.src('css/**/*.css')
+        .pipe(rebaseUrls({
+            convertToAbsolute: true,
+        }))
+        .pipe(concat('style.css')) // <-- just an example
+        .pipe(gulp.dest('./build/'));
+});
+```
+
+
+
 Pull requests and use cases welcome.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ var rebaseUrls = function(css, options) {
             if (process.platform === 'win32') {
                 p = p.replace(/\\/g, '/');
             }
-
+            if (options.convertToAbsolute) {
+                p = "/" + p;
+            }
             return p;
         }))
         .toString();
@@ -30,11 +32,13 @@ var rebaseUrls = function(css, options) {
 module.exports = function(options) {
     options = options || {};
     var root = options.root || '.';
+    var convertToAbsolute = options.convertToAbsolute || false;
 
     return through.obj(function(file, enc, cb) {
         var css = rebaseUrls(file.contents.toString(), {
             currentDir: path.dirname(file.path),
-            root: path.join(file.cwd, root)
+            root: path.join(file.cwd, root),
+            convertToAbsolute: convertToAbsolute
         });
 
         file.contents = new Buffer(css);


### PR DESCRIPTION
This is to accommodate the situation where the CSS files are being located to another directory but the associated images are not being relocated.
