### PR TITLE
exception handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var rework = require('rework');
 var path = require('path');
 var through = require('through2');
 var validator = require('validator');
+var gutil = require('gulp-util');
 
 var isAbsolute = function(p) {
     var normal = path.normalize(p);
@@ -32,12 +33,17 @@ module.exports = function(options) {
     var root = options.root || '.';
 
     return through.obj(function(file, enc, cb) {
-        var css = rebaseUrls(file.contents.toString(), {
-            currentDir: path.dirname(file.path),
-            root: path.join(file.cwd, root)
-        });
+        try {
+            var css = rebaseUrls(file.contents.toString(), {
+                currentDir: path.dirname(file.path),
+                root: path.join(file.cwd, root)
+            });
 
-        file.contents = new Buffer(css);
+            file.contents = new Buffer(css);
+        } catch (err) {
+            cb(new gutil.PluginError('gulp-css-rebase-urls', err));
+            return;
+        }
 
         this.push(file);
         cb();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Rebase relative image URLs",
   "main": "index.js",
   "dependencies": {
+    "gulp-util": "~2.2.13",
     "rework": "~0.20.2",
     "validator": "~3.1.0",
     "through2": "~0.4.0"


### PR DESCRIPTION
Prevents gulp-css-rebase-urls from silently killing gulp task if an error occurs while processing files. Instead the error will be wrapped in a PluginError and passed up to the pipeline for handling.