### PR TITLE
Update rework to latest version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var rework = require('rework');
+var reworkUrl = require('rework-plugin-url');
 var path = require('path');
 var through = require('through2');
 var validator = require('validator');
@@ -11,7 +12,7 @@ var isAbsolute = function(p) {
 
 var rebaseUrls = function(css, options) {
     return rework(css)
-        .use(rework.url(function(url){
+        .use(reworkUrl(function(url){
             if (isAbsolute(url) && validator.isURL(url)) {
                 return url;
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Rebase relative image URLs",
   "main": "index.js",
   "dependencies": {
-    "rework": "~0.20.2",
+    "rework": "^1.0.1",
+    "rework-plugin-url": "^1.0.1",
     "validator": "~3.1.0",
     "through2": "~0.4.0"
   },


### PR DESCRIPTION
Updates to rework 1.0.1 and pulls in rework-plugin-url (as replacement for old `rework.url` which is no longer in core) in order to take advantage of bug fixes not present in the older version currently used by gulp-css-rebase-urls.
