### PR TITLE
http(s)://-URLs should not be rebased

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var isAbsolute = function(p) {
 var rebaseUrls = function(css, options) {
     return rework(css)
         .use(rework.url(function(url){
-            if (isAbsolute(url) && validator.isURL(url)) {
+            if (isAbsolute(url) || validator.isURL(url)) {
                 return url;
             }
             var absolutePath = path.join(options.currentDir, url)


### PR DESCRIPTION
I guess the check 

``` javascript
if (isAbsolute(url) && validator.isURL(url)) { ... }
```

should really read `||`? In case of URLs starting with "http(s)://...", isAbsolute() will return false but isURL() returns true.
